### PR TITLE
packages key is necessary in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 onlyBuiltDependencies:
   - esbuild
+packages:
+  - .


### PR DESCRIPTION
pnpm -v 10.4.0

Without this, 
```
$ pnpm run dev
 ERROR  packages field missing or empty
For help, run: pnpm help run
```
but `npm run dev` don't create this problem. 
For more info - https://github.com/pnpm/pnpm/issues/8968